### PR TITLE
[P2PS] Ameerul /P2PS-1994 Wrong title for buy/sell modal from advertiser page

### DIFF
--- a/packages/p2p/src/components/modal-manager/modals/buy-sell-modal/__tests__/buy-sell-modal.spec.tsx
+++ b/packages/p2p/src/components/modal-manager/modals/buy-sell-modal/__tests__/buy-sell-modal.spec.tsx
@@ -59,7 +59,6 @@ describe('<BuySellModal />', () => {
                 },
                 table_type: 'buy',
                 fetchAdvertiserAdverts: jest.fn(),
-                is_buy: true,
                 is_buy_advert: true,
                 setFormErrorCode: jest.fn(),
                 unsubscribeAdvertInfo: jest.fn(),

--- a/packages/p2p/src/components/modal-manager/modals/buy-sell-modal/buy-sell-modal.tsx
+++ b/packages/p2p/src/components/modal-manager/modals/buy-sell-modal/buy-sell-modal.tsx
@@ -17,7 +17,7 @@ import BuySellModalError from './buy-sell-modal-error';
 const BuySellModal = () => {
     const { hideModal, is_modal_open, showModal } = useModalManagerContext();
     const { buy_sell_store, general_store, my_profile_store, order_store } = useStores();
-    const { is_buy, selected_ad_state } = buy_sell_store;
+    const { is_buy_advert, selected_ad_state } = buy_sell_store;
     const { balance } = general_store;
     const { should_show_add_payment_method_form } = my_profile_store;
 
@@ -28,7 +28,7 @@ const BuySellModal = () => {
     const [is_account_balance_low, setIsAccountBalanceLow] = React.useState(false);
     const submitForm = React.useRef<(() => void) | null>(null);
 
-    const show_low_balance_message = !is_buy && is_account_balance_low;
+    const show_low_balance_message = !is_buy_advert && is_account_balance_low;
 
     const setSubmitForm = (submitFormFn: () => void) => (submitForm.current = submitFormFn);
 
@@ -110,7 +110,7 @@ const BuySellModal = () => {
                     is_flex
                     is_modal_open={is_modal_open}
                     page_header_className='buy-sell-modal__header'
-                    renderPageHeaderElement={<BuySellModalTitle is_buy={is_buy} />}
+                    renderPageHeaderElement={<BuySellModalTitle is_buy={is_buy_advert} />}
                     pageHeaderReturnFn={onCancel}
                 >
                     <BuySellModalError
@@ -144,15 +144,15 @@ const BuySellModal = () => {
                     className={classNames('buy-sell-modal', {
                         'buy-sell-modal__form': should_show_add_payment_method_form,
                     })}
-                    height={is_buy ? 'auto' : '649px'}
+                    height={is_buy_advert ? 'auto' : '649px'}
                     is_open={is_modal_open}
                     portalId='modal_root'
-                    title={<BuySellModalTitle is_buy={is_buy} />}
+                    title={<BuySellModalTitle is_buy={is_buy_advert} />}
                     toggleModal={onCancel}
                     width='456px'
                 >
                     {/* Parent height - Modal.Header height - Modal.Footer height */}
-                    <ThemedScrollbars height={is_buy ? '100%' : 'calc(100% - 5.8rem - 7.4rem)'}>
+                    <ThemedScrollbars height={is_buy_advert ? '100%' : 'calc(100% - 5.8rem - 7.4rem)'}>
                         <Modal.Body className='buy-sell-modal__layout'>
                             <BuySellModalError
                                 error_message={error_message}

--- a/packages/p2p/src/pages/buy-sell/buy-sell-form.jsx
+++ b/packages/p2p/src/pages/buy-sell/buy-sell-form.jsx
@@ -29,7 +29,7 @@ const BuySellForm = props => {
         buy_sell_store.setFormProps(props);
     }, [props, buy_sell_store]);
 
-    const { advert, setIsSubmitDisabled, setPageFooterParent, setSubmitForm } = props;
+    const { advert, setPageFooterParent } = props;
     const {
         advertiser_details,
         description,
@@ -161,7 +161,7 @@ const BuySellForm = props => {
     };
 
     React.useEffect(() => {
-        setIsSubmitDisabled(
+        buy_sell_store.form_props.setIsSubmitDisabled(
             !isValid ||
                 isSubmitting ||
                 (buy_sell_store.is_sell_advert && payment_method_names && selected_methods.length < 1)
@@ -170,13 +170,13 @@ const BuySellForm = props => {
         isValid,
         isSubmitting,
         selected_methods.length,
-        buy_sell_store.form_props,
         buy_sell_store.is_sell_advert,
         payment_method_names,
+        buy_sell_store.form_props,
     ]);
 
     React.useEffect(() => {
-        setSubmitForm(submitForm);
+        buy_sell_store.form_props.setSubmitForm(submitForm);
     }, [submitForm, buy_sell_store.form_props]);
 
     return (


### PR DESCRIPTION
## Changes:

Please provide a summary of the change.
- Fixed modal title not displaying correctly. Checked is_buy_advert instead of is_buy since is_buy checks only if the user is in buy/sell page, which tracks which tab the user is in, which is defaulted to Buy. is_buy_advert checks the advert's counterparty_type which is better to check.
- Also fixed the first time login issue with confirming the order, for some reason it doesn't pass the submitForm function to BuySellModal component when directly calling it from props and not the store value form_props. Opted to use store value instead

### Screenshots:

Please provide some screenshots of the change.
